### PR TITLE
Rename multiError.Add to .Append?

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ err := multierror.New()
 
 err == nil  // Just like a normal error, it can be nil by default.
 
-err.Add(nil)
+err.Append(nil)
 err == nil  // It's still nil, even if we add a nil error
 
 anError := errors.New("some error")
-err.Add(anError)
+err.Append(anError)
 
 err != nil  // Once a non-nil error is added, it's non-nil just like normal errors.
 
@@ -39,9 +39,9 @@ MultiError is convenient to use in different scenarios.
 // Do a bunch of things that might fail independently and check for errors once in the end:
 err := multierror.New()
 
-err.Add(makeNil(...))
-err.Add(makeErr(...))
-err.Add(makeErr(...))
+err.Append(makeNil(...))
+err.Append(makeErr(...))
+err.Append(makeErr(...))
 
 if err != nil {
 	// Oh noes, we had a failure.
@@ -60,9 +60,9 @@ if err := maybeFail(); err != nil { ... }
 // We can do:
 err := multierror.New()
 
-if err.Add(maybeFail()) != nil { ... }
+if err.Append(maybeFail()) != nil { ... }
 
-// err.Add(nil) == nil and err.Add(error) != nil
+// err.Append(nil) == nil and err.Append(error) != nil
 ```
 
 ## How is this better?
@@ -86,7 +86,7 @@ if err.Add(maybeFail()) != nil { ... }
 
 * It's not goroutine-safe out of the box, same as any other slice type.
 
-* It uses a pointer receiver for `.Add` and a value receiver for `.Error`
+* It uses a pointer receiver for `.Append` and a value receiver for `.Error`
   in order to satisfy the Error semantics. Please open an issue if there are
   specific problems in this case.
 

--- a/example_test.go
+++ b/example_test.go
@@ -21,9 +21,9 @@ func Example() {
 	// happen independently and we only care about the state between phases.
 
 	// First phase
-	errors.Add(okay("a")) // == nil
-	errors.Add(okay("b")) // == nil
-	errors.Add(okay("c")) // == nil
+	errors.Append(okay("a")) // == nil
+	errors.Append(okay("b")) // == nil
+	errors.Append(okay("c")) // == nil
 
 	// Handle possible errors
 	if errors != nil {
@@ -32,9 +32,9 @@ func Example() {
 	}
 
 	// Second phase
-	errors.Add(oops("d")) // != nil
-	errors.Add(oops("e")) // != nil
-	errors.Add(okay("f")) // != nil, because an error has already occurred.
+	errors.Append(oops("d")) // != nil
+	errors.Append(oops("e")) // != nil
+	errors.Append(okay("f")) // != nil, because an error has already occurred.
 
 	// Handle pssible errors
 	if errors != nil {

--- a/multierror.go
+++ b/multierror.go
@@ -20,19 +20,19 @@ func New(errors ...error) multiError {
 // multiError is not exported to avoid confusion from users who run into multiError{} != nil.
 type multiError []error
 
-// Add an error to multiError, return an error representing the multiError state.
+//.Append an error to multiError, return an error representing the multiError state.
 // nil errors are ignored.
-func (e *multiError) Add(err error) error {
+func (e *multiError) Append(err error) error {
 	if err == nil {
 		if len(*e) == 0 {
-			// nil e.Add(nil) is still nil
+			// nil e.Append(nil) is still nil
 			return nil
 		}
-		// non-nil e.Add(nil) is not nil
+		// non-nil e.Append(nil) is not nil
 		return e
 	}
 	if e == nil {
-		// nil e.Add(error) will instantiate itself
+		// nil e.Append(error) will instantiate itself
 		*e = []error{err}
 		return e
 	}

--- a/multierror_test.go
+++ b/multierror_test.go
@@ -10,13 +10,13 @@ func ExampleNew() {
 	err := New()
 	// err == nil
 
-	err.Add(nil)
-	// err.Add(nil) == nil
+	err.Append(nil)
+	// err.Append(nil) == nil
 	// err == nil
 
 	anErr := errors.New("an error")
-	err.Add(anErr)
-	// err.Add(anErr) != nil
+	err.Append(anErr)
+	// err.Append(anErr) != nil
 	// err != nil
 
 	fmt.Println(err)
@@ -28,8 +28,8 @@ func ExampleNew_multiple() {
 	// err == nil
 
 	anErr := errors.New("an error")
-	err.Add(anErr)
-	err.Add(anErr)
+	err.Append(anErr)
+	err.Append(anErr)
 
 	fmt.Println(err)
 	// Output: 2 errors: an error; an error
@@ -79,39 +79,39 @@ func TestErrorCompat(t *testing.T) {
 
 	// Single error should produce the same .Error()
 	anErr := errors.New("some error")
-	err.Add(anErr)
+	err.Append(anErr)
 	if got, want := err.Error(), anErr.Error(); want != got {
 		t.Errorf("got %q; want %q", got, want)
 	}
 }
 
-// Test the primary intended, using New and Add.
+// Test the primary intended, using New and .Append
 func TestErrors(t *testing.T) {
 	err := New()
 	if err != nil {
 		t.Error("new MultiError is not nil")
 	}
 
-	if e := err.Add(nil); e != nil {
-		t.Error("err.Add(nil) returned non-nil")
+	if e := err.Append(nil); e != nil {
+		t.Error("err.Append(nil) returned non-nil")
 	}
 	if err != nil {
-		t.Error("err.Add(nil) is not nil")
+		t.Error("err.Append(nil) is not nil")
 	}
 
 	anErr := errors.New("an error")
-	if e := err.Add(anErr); e == nil {
-		t.Error("err.Add(Error) returned nil")
+	if e := err.Append(anErr); e == nil {
+		t.Error("err.Append(Error) returned nil")
 	}
 	if err == nil {
-		t.Error("err.Add(Error) is nil")
+		t.Error("err.Append(Error) is nil")
 	}
 	if got, want := err.Error(), "an error"; got != want {
 		t.Errorf("got %q; want %q", got, want)
 	}
 
-	if e := err.Add(anErr); e == nil {
-		t.Error("err.Add(Error) returned nil")
+	if e := err.Append(anErr); e == nil {
+		t.Error("err.Append(Error) returned nil")
 	}
 	if got, want := err.Error(), "2 errors: an error; an error"; got != want {
 		t.Errorf("got %q; want %q", got, want)
@@ -125,8 +125,8 @@ func TestAlternate(t *testing.T) {
 		t.Error("manual multiError is nil")
 	}
 
-	err.Add(errors.New("an error"))
-	err.Add(errors.New("another error"))
+	err.Append(errors.New("an error"))
+	err.Append(errors.New("another error"))
 
 	if len(err) != 2 {
 		t.Error("err length is not 2")


### PR DESCRIPTION
I think we'd need to change the return semantics for this to make sense.
